### PR TITLE
Close websocket connection after unsubscribing to all subscriptions

### DIFF
--- a/src/common/websocketApi.js
+++ b/src/common/websocketApi.js
@@ -66,6 +66,7 @@ const WEBSOCKET = {
       subscriptions[tag].unsubscribe()
       delete subscriptions[tag]
     }
+    this.close()
   },
 
   /**


### PR DESCRIPTION
Fixes bug where old jwt is used when tournament host creates a new tournament after he ended another tournament